### PR TITLE
feat: enforce bid cap, stage homeowner contact unlocking, and add tra…

### DIFF
--- a/src/components/Trade-CRM/HomePlusJobsFeed.tsx
+++ b/src/components/Trade-CRM/HomePlusJobsFeed.tsx
@@ -56,7 +56,7 @@ import { toast } from '@/lib/toast';
 import { useAuth } from '@/hooks/useAuth';
 import { updateTradePilotMe } from '@/lib/api';
 import TradeAreaMap, { type LocationChange } from '@/components/Trade-CRM/TradeAreaMap';
-import { getCategoriesForSpecialty } from '@/lib/jobCategories';
+import { getCategoriesForSpecialty, getTradeLabel } from '@/lib/jobCategories';
 import { cn } from '@/lib/utils';
 
 const _jobMarkerIcon = L.icon({
@@ -126,6 +126,7 @@ const JOBS_URL = '/api/v1/tradepilot/jobs/';
 const MY_BIDS_URL = '/api/v1/tradepilot/jobs/my-bids/';
 const ME_URL = '/api/v1/tradepilot/auth/me/';
 const MIN_BID_COST = 10;
+const MAX_BIDS_PER_JOB = 4;
 
 const QUESTION_LABELS: Record<string, string> = {
   // Plumbing – Boilers
@@ -300,12 +301,13 @@ interface UnlockedInfo {
   postcode: string;
   latitude: number | null;
   longitude: number | null;
+  contact_unlocked: boolean;
   homeowner: {
     first_name: string;
     last_name: string;
     email: string;
     phone: string;
-  };
+  } | null;
 }
 
 interface JobFile {
@@ -327,6 +329,7 @@ interface Job {
   preferred_date: string | null;
   property_detail: PropertyDetail | null;
   already_bid: boolean;
+  is_full: boolean;
   files_count: number;
   bids_count: number;
   bid_credits: number;
@@ -360,6 +363,10 @@ interface MyBid {
   rated_at: string | null;
   created_at: string;
   homeowner: Homeowner | null;
+}
+
+function formatAnswerKey(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 function timeAgo(dateStr: string): string {
@@ -420,6 +427,7 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
   const [bidAvailability, setBidAvailability] = useState('');
   const [bidSuccess, setBidSuccess] = useState(false);
   const [contactBid, setContactBid] = useState<MyBid | null>(null);
+  const [detailBid, setDetailBid] = useState<MyBid | null>(null);
 
   useEffect(() => {
     if (settingsOpen && profile) {
@@ -605,10 +613,10 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
             )}
             <Select value={sortBy} onValueChange={v => setSortBy(v as typeof sortBy)}>
               <SelectTrigger className="h-8 w-40 rounded-lg bg-white text-[13px]">
-                <span className="inline-flex items-center gap-1.5">
+                <div className="flex items-center gap-1.5">
                   <ArrowDownUp className="h-3.5 w-3.5 text-gray-400" />
                   <SelectValue />
-                </span>
+                </div>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="newest">Newest</SelectItem>
@@ -668,8 +676,8 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                           </Badge>
                         </div>
                         <div className="mb-2.5 flex flex-wrap gap-1.5">
-                          <Badge tone="neutral" size="sm" className="capitalize">
-                            {job.trade}
+                          <Badge tone="neutral" size="sm">
+                            {getTradeLabel(job.trade)}
                           </Badge>
                           {job.category && (
                             <Badge tone="violet" size="sm">
@@ -690,8 +698,10 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                         )}
                         <span className="inline-flex items-center gap-1">
                           <Briefcase className="h-[13px] w-[13px]" />
-                          <span className="font-mono tabular-nums">{job.bids_count}</span> bid
-                          {job.bids_count !== 1 ? 's' : ''}
+                          <span className="font-mono tabular-nums">
+                            {job.bids_count}/{MAX_BIDS_PER_JOB}
+                          </span>{' '}
+                          bids
                         </span>
                         <span className="inline-flex items-center gap-1.5">
                           <span className={cn('h-1.5 w-1.5 rounded-full', toneDot[comp.tone])} />
@@ -713,6 +723,11 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                           <span className="inline-flex items-center gap-1.5 text-[13px] font-medium text-green-600">
                             <CheckCircle2 className="h-4 w-4" />
                             Bid placed
+                          </span>
+                        ) : job.is_full ? (
+                          <span className="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-400">
+                            <Lock className="h-3.5 w-3.5" />
+                            Bidding closed
                           </span>
                         ) : (
                           <Button
@@ -825,13 +840,19 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
             </div>
           ) : (
             myBids.map(bid => (
-              <div key={bid.id} className="rounded-xl border bg-card p-5 shadow-xs">
+              <div
+                key={bid.id}
+                onClick={() => setDetailBid(bid)}
+                className="cursor-pointer rounded-xl border bg-card p-5 shadow-xs transition-all hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md"
+              >
                 <div className="flex flex-wrap items-center gap-4">
                   <div className="min-w-0 flex-1">
                     <div className="mb-1.5 flex flex-wrap items-center gap-2">
-                      <span className="text-h3 font-semibold text-foreground">{bid.job_title}</span>
-                      <Badge tone="neutral" size="sm" className="capitalize">
-                        {bid.job_trade}
+                      <span className="text-h3 font-semibold text-foreground capitalize">
+                        {bid.job_title}
+                      </span>
+                      <Badge tone="neutral" size="sm">
+                        {getTradeLabel(bid.job_trade)}
                       </Badge>
                       <Badge tone={bidStatusTone[bid.status] ?? 'neutral'} size="sm" dot>
                         {bid.status.charAt(0).toUpperCase() + bid.status.slice(1)}
@@ -878,7 +899,14 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                     )}
                   </div>
                   {bid.status === 'accepted' && bid.homeowner ? (
-                    <Button variant="outline" size="sm" onClick={() => setContactBid(bid)}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={e => {
+                        e.stopPropagation();
+                        setContactBid(bid);
+                      }}
+                    >
                       <User className="h-[15px] w-[15px]" />
                       View contact
                     </Button>
@@ -903,8 +931,8 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                     {detailJob.title}
                   </h2>
                   <div className="flex flex-wrap gap-1.5">
-                    <Badge tone="neutral" size="sm" className="capitalize">
-                      {detailJob.trade}
+                    <Badge tone="neutral" size="sm">
+                      {getTradeLabel(detailJob.trade)}
                     </Badge>
                     {detailJob.category && (
                       <Badge tone="violet" size="sm">
@@ -999,7 +1027,7 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                           .map(([key, val]) => (
                             <div key={key} className="flex gap-3 px-3 py-2">
                               <span className="min-w-[120px] shrink-0 pt-0.5 text-xs text-muted-foreground">
-                                {QUESTION_LABELS[key] ?? key.replace(/_/g, ' ')}
+                                {QUESTION_LABELS[key] ?? formatAnswerKey(key)}
                               </span>
                               <span className="text-xs font-medium text-foreground">{String(val)}</span>
                             </div>
@@ -1011,8 +1039,10 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                 <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
                   <span className="inline-flex items-center gap-1">
                     <Briefcase className="h-[13px] w-[13px]" />
-                    <span className="font-mono tabular-nums">{detailJob.bids_count}</span> bid
-                    {detailJob.bids_count !== 1 ? 's' : ''} so far
+                    <span className="font-mono tabular-nums">
+                      {detailJob.bids_count}/{MAX_BIDS_PER_JOB}
+                    </span>{' '}
+                    bids so far
                   </span>
                 </div>
 
@@ -1039,14 +1069,16 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                   </div>
                 )}
 
-                {/* Homeowner contact — unlocked after bidding */}
+                {/* Homeowner contact — location unlocks on bid, contact unlocks on acceptance */}
                 <div>
                   <SectionLabel className="mb-2">Homeowner contact</SectionLabel>
                   {detailJob.unlocked_info ? (
                     <div className="space-y-3 rounded-xl border border-teal-200 bg-teal-50/60 p-4">
                       <div className="flex items-center gap-2 text-xs font-semibold text-teal-700">
                         <CheckCircle2 className="h-4 w-4 shrink-0" />
-                        Bid placed — contact &amp; location unlocked
+                        {detailJob.unlocked_info.contact_unlocked
+                          ? 'Bid accepted — contact & location unlocked'
+                          : 'Bid placed — location unlocked'}
                       </div>
 
                       {(detailJob.unlocked_info.address || detailJob.unlocked_info.postcode) && (
@@ -1072,39 +1104,244 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                         />
                       )}
 
-                      <div className="flex items-center gap-3 pt-1">
+                      {detailJob.unlocked_info.contact_unlocked && detailJob.unlocked_info.homeowner ? (
+                        <>
+                          <div className="flex items-center gap-3 pt-1">
+                            <UserAvatar
+                              name={`${detailJob.unlocked_info.homeowner.first_name} ${detailJob.unlocked_info.homeowner.last_name}`}
+                              size="sm"
+                            />
+                            <div>
+                              <p className="text-sm font-semibold text-foreground">
+                                {detailJob.unlocked_info.homeowner.first_name}{' '}
+                                {detailJob.unlocked_info.homeowner.last_name}
+                              </p>
+                              <p className="text-xs text-muted-foreground">Homeowner</p>
+                            </div>
+                          </div>
+
+                          <div className="space-y-2">
+                            {detailJob.unlocked_info.homeowner.email && (
+                              <a
+                                href={`mailto:${detailJob.unlocked_info.homeowner.email}`}
+                                className="flex items-center gap-2 rounded-lg border border-teal-200 bg-white p-2.5 text-sm text-gray-700 transition-colors hover:bg-teal-50"
+                              >
+                                <Mail className="h-4 w-4 shrink-0 text-gray-400" />
+                                <span className="truncate">{detailJob.unlocked_info.homeowner.email}</span>
+                              </a>
+                            )}
+                            {detailJob.unlocked_info.homeowner.phone && (
+                              <a
+                                href={`tel:${detailJob.unlocked_info.homeowner.phone}`}
+                                className="flex items-center gap-2 rounded-lg border border-teal-200 bg-white p-2.5 text-sm text-gray-700 transition-colors hover:bg-teal-50"
+                              >
+                                <Phone className="h-4 w-4 shrink-0 text-gray-400" />
+                                <span className="font-mono tabular-nums">
+                                  {detailJob.unlocked_info.homeowner.phone}
+                                </span>
+                              </a>
+                            )}
+                          </div>
+                        </>
+                      ) : (
+                        <div className="relative overflow-hidden rounded-lg border border-teal-200/70">
+                          <div className="select-none space-y-2.5 bg-white/70 p-3.5 blur-sm" aria-hidden="true">
+                            <div className="flex items-center gap-2.5">
+                              <span className="h-9 w-9 rounded-full bg-gray-200" />
+                              <div>
+                                <p className="text-sm font-semibold text-foreground">John D.</p>
+                                <p className="text-xs text-gray-400">Homeowner</p>
+                              </div>
+                            </div>
+                            <div className="text-[13px] text-muted-foreground">+44 7700 ••• •••</div>
+                          </div>
+                          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-white/60">
+                            <Lock className="h-4 w-4 text-muted-foreground" />
+                            <span className="px-4 text-center text-xs font-semibold text-gray-700">
+                              Contact unlocks once the homeowner accepts your bid
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="relative overflow-hidden rounded-xl border">
+                      <div className="select-none space-y-2.5 p-4 blur-sm" aria-hidden="true">
+                        <div className="flex items-center gap-2.5">
+                          <span className="h-9 w-9 rounded-full bg-gray-200" />
+                          <div>
+                            <p className="text-sm font-semibold text-foreground">John D.</p>
+                            <p className="text-xs text-gray-400">Homeowner</p>
+                          </div>
+                        </div>
+                        <div className="text-[13px] text-muted-foreground">+44 7700 ••• •••</div>
+                        <div className="text-[13px] text-muted-foreground">j••••@gmail.com</div>
+                      </div>
+                      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-white/55">
+                        <span className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white text-muted-foreground shadow-sm">
+                          <Lock className="h-4 w-4" />
+                        </span>
+                        <span className="px-4 text-center text-xs font-semibold text-gray-700">
+                          Place a bid to unlock location
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-gray-100 bg-card px-6 py-4">
+                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Coins className="h-3.5 w-3.5 text-orange-500" />
+                  <span className="font-mono tabular-nums">{detailJob.bid_credits}</span> credits to bid
+                </span>
+                {detailJob.already_bid ? (
+                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-green-600">
+                    <CheckCircle2 className="h-4 w-4" />
+                    Bid already sent
+                  </span>
+                ) : detailJob.is_full ? (
+                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-400">
+                    <Lock className="h-4 w-4" />
+                    Bidding closed — {MAX_BIDS_PER_JOB} bids received
+                  </span>
+                ) : (
+                  <Button
+                    disabled={creditBalance < detailJob.bid_credits}
+                    onClick={() => openBidDialog(detailJob)}
+                  >
+                    Place bid
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* Bid detail — right-side sheet */}
+      <Sheet open={!!detailBid} onOpenChange={open => !open && setDetailBid(null)}>
+        <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-y-auto p-0 sm:max-w-[480px]">
+          {detailBid && (
+            <>
+              <div className="flex items-start gap-3.5 border-b border-gray-100 p-6 pb-5 pr-12">
+                <div>
+                  <h2 className="mb-2 text-h2 font-semibold leading-snug text-foreground">
+                    {detailBid.job_title}
+                  </h2>
+                  <div className="flex flex-wrap gap-1.5">
+                    <Badge tone="neutral" size="sm">
+                      {getTradeLabel(detailBid.job_trade)}
+                    </Badge>
+                    <Badge tone={bidStatusTone[detailBid.status] ?? 'neutral'} size="sm" dot>
+                      {detailBid.status.charAt(0).toUpperCase() + detailBid.status.slice(1)}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-1 flex-col gap-5 p-6">
+                {detailBid.description && (
+                  <div>
+                    <SectionLabel className="mb-2">Your bid message</SectionLabel>
+                    <p className="text-sm leading-relaxed text-gray-700">{detailBid.description}</p>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-3 gap-2.5">
+                  <div className="rounded-lg bg-gray-50 px-3 py-2.5">
+                    <div className="mb-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <Coins className="h-3 w-3" />
+                      Your bid
+                    </div>
+                    <div className="font-mono text-[13px] font-semibold tabular-nums text-foreground">
+                      £{parseFloat(detailBid.amount).toFixed(0)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-gray-50 px-3 py-2.5">
+                    <div className="mb-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <Clock className="h-3 w-3" />
+                      Submitted
+                    </div>
+                    <div className="text-[13px] font-semibold text-foreground">
+                      {timeAgo(detailBid.created_at)}
+                    </div>
+                  </div>
+                  {detailBid.availability && (
+                    <div className="rounded-lg bg-gray-50 px-3 py-2.5">
+                      <div className="mb-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Calendar className="h-3 w-3" />
+                        Available
+                      </div>
+                      <div className="font-mono text-[13px] font-semibold tabular-nums text-foreground">
+                        {new Date(detailBid.availability).toLocaleDateString('en-GB')}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                  <span className="inline-flex items-center gap-1">
+                    Job status:{' '}
+                    <span
+                      className={cn(
+                        'font-medium capitalize',
+                        detailBid.job_status === 'completed' ? 'text-green-600' : 'text-gray-600'
+                      )}
+                    >
+                      {detailBid.job_status.replace('_', ' ')}
+                    </span>
+                  </span>
+                </div>
+
+                {detailBid.rating != null && (
+                  <div>
+                    <SectionLabel className="mb-2">Homeowner rating</SectionLabel>
+                    <div className="flex items-center gap-1.5 rounded-lg bg-amber-50 px-3.5 py-3 text-[13px] text-amber-700">
+                      <Star className="h-4 w-4 fill-amber-500 text-amber-500" />
+                      <span className="font-mono font-semibold tabular-nums">{detailBid.rating}/5</span>
+                      {detailBid.rating_comment && (
+                        <span className="text-amber-600">— {detailBid.rating_comment}</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* Homeowner contact — unlocked once the bid is accepted */}
+                <div>
+                  <SectionLabel className="mb-2">Homeowner contact</SectionLabel>
+                  {detailBid.status === 'accepted' && detailBid.homeowner ? (
+                    <div className="space-y-3 rounded-xl border border-teal-200 bg-teal-50/60 p-4">
+                      <div className="flex items-center gap-3">
                         <UserAvatar
-                          name={`${detailJob.unlocked_info.homeowner.first_name} ${detailJob.unlocked_info.homeowner.last_name}`}
+                          name={`${detailBid.homeowner.first_name} ${detailBid.homeowner.last_name}`}
                           size="sm"
                         />
                         <div>
                           <p className="text-sm font-semibold text-foreground">
-                            {detailJob.unlocked_info.homeowner.first_name}{' '}
-                            {detailJob.unlocked_info.homeowner.last_name}
+                            {detailBid.homeowner.first_name} {detailBid.homeowner.last_name}
                           </p>
                           <p className="text-xs text-muted-foreground">Homeowner</p>
                         </div>
                       </div>
-
                       <div className="space-y-2">
-                        {detailJob.unlocked_info.homeowner.email && (
+                        {detailBid.homeowner.email && (
                           <a
-                            href={`mailto:${detailJob.unlocked_info.homeowner.email}`}
+                            href={`mailto:${detailBid.homeowner.email}`}
                             className="flex items-center gap-2 rounded-lg border border-teal-200 bg-white p-2.5 text-sm text-gray-700 transition-colors hover:bg-teal-50"
                           >
                             <Mail className="h-4 w-4 shrink-0 text-gray-400" />
-                            <span className="truncate">{detailJob.unlocked_info.homeowner.email}</span>
+                            <span className="truncate">{detailBid.homeowner.email}</span>
                           </a>
                         )}
-                        {detailJob.unlocked_info.homeowner.phone && (
+                        {detailBid.homeowner.phone && (
                           <a
-                            href={`tel:${detailJob.unlocked_info.homeowner.phone}`}
+                            href={`tel:${detailBid.homeowner.phone}`}
                             className="flex items-center gap-2 rounded-lg border border-teal-200 bg-white p-2.5 text-sm text-gray-700 transition-colors hover:bg-teal-50"
                           >
                             <Phone className="h-4 w-4 shrink-0 text-gray-400" />
-                            <span className="font-mono tabular-nums">
-                              {detailJob.unlocked_info.homeowner.phone}
-                            </span>
+                            <span className="font-mono tabular-nums">{detailBid.homeowner.phone}</span>
                           </a>
                         )}
                       </div>
@@ -1127,33 +1364,12 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                           <Lock className="h-4 w-4" />
                         </span>
                         <span className="px-4 text-center text-xs font-semibold text-gray-700">
-                          Place a bid to unlock contact &amp; location
+                          Contact unlocks once the homeowner accepts your bid
                         </span>
                       </div>
                     </div>
                   )}
                 </div>
-              </div>
-
-              <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-gray-100 bg-card px-6 py-4">
-                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <Coins className="h-3.5 w-3.5 text-orange-500" />
-                  <span className="font-mono tabular-nums">{detailJob.bid_credits}</span> credits to bid
-                </span>
-                {detailJob.already_bid ? (
-                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-green-600">
-                    <CheckCircle2 className="h-4 w-4" />
-                    Bid already sent
-                  </span>
-                ) : (
-                  <Button
-                    disabled={creditBalance < detailJob.bid_credits}
-                    onClick={() => openBidDialog(detailJob)}
-                  >
-                    Place bid
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                )}
               </div>
             </>
           )}
@@ -1344,7 +1560,7 @@ const HomePlusJobsFeed = ({ creditBalance, onCreditChange }: Props) => {
                           .map(([key, val]) => (
                             <div key={key} className="flex gap-2 text-xs">
                               <span className="min-w-[96px] text-muted-foreground">
-                                {QUESTION_LABELS[key] ?? key.replace(/_/g, ' ')}
+                                {QUESTION_LABELS[key] ?? formatAnswerKey(key)}
                               </span>
                               <span className="text-foreground">{String(val)}</span>
                             </div>

--- a/src/components/Trade-CRM/TradeJobs.tsx
+++ b/src/components/Trade-CRM/TradeJobs.tsx
@@ -23,6 +23,7 @@ import { EmptyState } from '@/components/trade-pilot/EmptyState';
 import { urgencyBadgeTone, urgencyLabel } from '@/components/trade-pilot/tones';
 import { Briefcase, CalendarDays, Clock, Lock, MapPin, Star, Wallet } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getTradeLabel } from '@/lib/jobCategories';
 
 function timeAgo(dateStr: string) {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -87,7 +88,7 @@ const BidCardContent = ({ bid, isDragging = false }: { bid: any; isDragging?: bo
         </div>
 
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-          <span className="capitalize">{bid.job_trade}</span>
+          <span>{getTradeLabel(bid.job_trade)}</span>
           {bid.job_category && (
             <>
               <span className="text-gray-300">·</span>
@@ -326,6 +327,7 @@ export default function TradeJobs() {
   };
 
   const activeItem = activeID ? tasks.flatMap(col => col.items).find((item: any) => item.id === activeID) : null;
+  const hasJobs = tasks.some(col => col.items.length > 0);
 
   const pipelineValue = tasks
     .flatMap(col => col.items)
@@ -346,7 +348,7 @@ export default function TradeJobs() {
         {isLoading && <span className="text-sm text-muted-foreground">Loading…</span>}
       </PageTitle>
 
-      {!isLoading && tasks.every(col => col.items.length === 0) && (
+      {!isLoading && !hasJobs && (
         <div className="rounded-xl border border-dashed bg-card">
           <EmptyState
             icon={Briefcase}
@@ -356,39 +358,41 @@ export default function TradeJobs() {
         </div>
       )}
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={handleDragStart}
-        onDragOver={handleDragOver}
-        onDragEnd={handleDragEnd}
-      >
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {tasks.map(col => (
-            <DroppableColumn
-              key={col.id}
-              column={col}
-              visibleCount={visibleCounts[col.id] || 10}
-              onLoadMore={handleLoadMore}
-              isDraggingOver={overID === col.id}
-            >
-              <SortableContext items={col.items.map((item: any) => item.id)} strategy={verticalListSortingStrategy}>
-                {col.items.slice(0, visibleCounts[col.id] || 10).map((bid: any) => (
-                  <SortableBidCard key={bid.id} bid={bid} />
-                ))}
-              </SortableContext>
-            </DroppableColumn>
-          ))}
-        </div>
+      {hasJobs && (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {tasks.map(col => (
+              <DroppableColumn
+                key={col.id}
+                column={col}
+                visibleCount={visibleCounts[col.id] || 10}
+                onLoadMore={handleLoadMore}
+                isDraggingOver={overID === col.id}
+              >
+                <SortableContext items={col.items.map((item: any) => item.id)} strategy={verticalListSortingStrategy}>
+                  {col.items.slice(0, visibleCounts[col.id] || 10).map((bid: any) => (
+                    <SortableBidCard key={bid.id} bid={bid} />
+                  ))}
+                </SortableContext>
+              </DroppableColumn>
+            ))}
+          </div>
 
-        <DragOverlay dropAnimation={null}>
-          {activeItem && (
-            <div className="rotate-1 scale-105 cursor-grabbing shadow-2xl">
-              <BidCardContent bid={activeItem} isDragging />
-            </div>
-          )}
-        </DragOverlay>
-      </DndContext>
+          <DragOverlay dropAnimation={null}>
+            {activeItem && (
+              <div className="rotate-1 scale-105 cursor-grabbing shadow-2xl">
+                <BidCardContent bid={activeItem} isDragging />
+              </div>
+            )}
+          </DragOverlay>
+        </DndContext>
+      )}
     </div>
   );
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,7 +3,7 @@ import useFetch from './useFetch';
 import { usePost } from './usePost';
 import { apiRequest, BASE_URL } from '@/lib/apiClient';
 
-const ME_URL = '/api/v1/tradepilot/auth/me/';
+export const ME_URL = '/api/v1/tradepilot/auth/me/';
 
 export interface TradePilotUser {
   id: string;
@@ -31,6 +31,7 @@ export interface TradePilotUser {
   has_license: boolean;
   is_verified: boolean;
   profile_description: string;
+  profile_photo_url: string | null;
 }
 
 interface MeResponse {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,6 +43,10 @@ export const deleteData = <T = any>({ url }: { url: string }): Promise<T> =>
 export const updateTradePilotMe = (data: Record<string, any>) =>
   patchData({ url: 'api/v1/tradepilot/auth/me/', data });
 
+// Profile photo
+export const uploadTraderPhoto = (formData: FormData) =>
+  postData<any>({ url: 'api/v1/tradepilot/profile/photo/', data: formData });
+
 // My Bids (accepted HomePlus bids)
 export const fetchMyBids = () =>
   fetchData<any>('/api/v1/tradepilot/jobs/my-bids/').then(r => r?.data ?? []);

--- a/src/lib/jobCategories.ts
+++ b/src/lib/jobCategories.ts
@@ -47,3 +47,28 @@ export function getCategoriesForSpecialty(specialty: string | undefined): string
   if (!trade) return [];
   return JOB_CATEGORIES.filter(c => c.trade === trade).map(c => c.category);
 }
+
+// mirrors backend JobLead.TRADE_CHOICES (backend/apps/jobs/models.py) — display labels for job.trade values
+const TRADE_LABELS: Record<string, string> = {
+  plumber: 'Plumber',
+  electrician: 'Electrician',
+  builder: 'Builder',
+  decorator: 'Decorator',
+  roofer: 'Roofer',
+  carpenter: 'Carpenter',
+  plasterer: 'Plasterer',
+  tiler: 'Tiler',
+  gardener: 'Gardener',
+  gas_engineer: 'Gas Engineer',
+  cleaner: 'Cleaner',
+  handyman: 'Handyman',
+  locksmith: 'Locksmith',
+  glazier: 'Glazier',
+  hvac: 'HVAC Engineer',
+  other: 'Other',
+};
+
+export function getTradeLabel(trade: string | undefined | null): string {
+  if (!trade) return '';
+  return TRADE_LABELS[trade.trim().toLowerCase()] ?? trade;
+}

--- a/src/pages/trade-crm/Credits.tsx
+++ b/src/pages/trade-crm/Credits.tsx
@@ -6,7 +6,6 @@ import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Dialog,
@@ -34,7 +33,6 @@ import {
   History,
   Loader2,
   PieChart,
-  Settings,
   ShieldCheck,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -98,8 +96,6 @@ const Credits = () => {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [paying, setPaying] = useState(false);
   const [ledgerFilter, setLedgerFilter] = useState('all');
-  // TODO(backend): auto top-up is a local mock until the backend supports it
-  const [autoTopUp, setAutoTopUp] = useState(() => localStorage.getItem('tp_auto_topup') === '1');
 
   const balance = jobMarketCredits ?? (user as any)?.credit_balance ?? 0;
   const pkg = CREDIT_PACKAGES.find(p => p.id === selectedPkg)!;
@@ -113,12 +109,6 @@ const Credits = () => {
     queryKey: ['credit-history'],
     queryFn: () => fetchData('/api/v1/tradepilot/jobs/credit-history/').then((res: any) => res?.data ?? res),
   });
-
-  const handleAutoTopUp = (next: boolean) => {
-    setAutoTopUp(next);
-    localStorage.setItem('tp_auto_topup', next ? '1' : '0');
-    toast(next ? 'Auto top-up enabled (saved on this device)' : 'Auto top-up disabled');
-  };
 
   const handlePay = async () => {
     setPaying(true);
@@ -205,15 +195,10 @@ const Credits = () => {
       <PageTitle
         title="Credits & billing"
         subtitle="Buy credits, track spending and manage your billing."
-      >
-        <Button variant="outline" onClick={() => toast('Billing settings are coming soon')}>
-          <Settings className="h-4 w-4" />
-          Billing settings
-        </Button>
-      </PageTitle>
+      />
 
       {/* Row 1: balance + buy credits */}
-      <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-[1fr_1.35fr]">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1.35fr]">
         {/* Navy balance panel */}
         <div className="rounded-xl bg-navy-800 p-6 text-white shadow-sm">
           <div className="mb-4 flex items-center justify-between">
@@ -240,16 +225,6 @@ const Credits = () => {
                 'Top up to start bidding'
               )}
             </span>
-          </div>
-          <div className="my-5 h-px bg-white/10" />
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div className="text-[13px] font-semibold text-white">Auto top-up</div>
-              <div className="text-[11px] text-white/55">
-                +50 credits when you drop below 20
-              </div>
-            </div>
-            <Switch checked={autoTopUp} onCheckedChange={handleAutoTopUp} />
           </div>
         </div>
 
@@ -311,7 +286,7 @@ const Credits = () => {
       </div>
 
       {/* Row 2: usage analytics */}
-      <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-[1.35fr_1fr]">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.35fr_1fr]">
         <SectionCard
           title="Credit usage"
           subtitle="Credits spent per month"

--- a/src/pages/trade-crm/Dashboard.tsx
+++ b/src/pages/trade-crm/Dashboard.tsx
@@ -47,6 +47,7 @@ import {
 } from 'lucide-react';
 import type { TradeCRMOutletContext } from '@/layouts/TradeCRMLayout';
 import { cn } from '@/lib/utils';
+import { getTradeLabel } from '@/lib/jobCategories';
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -312,7 +313,7 @@ const Dashboard = () => {
                       <div className="mt-1 flex flex-wrap gap-3 text-xs text-muted-foreground">
                         <span className="inline-flex items-center gap-1">
                           <Wrench className="h-3 w-3" />
-                          {job.trade || job.category}
+                          {getTradeLabel(job.trade) || job.category}
                         </span>
                         {job.distance_km != null && (
                           <span className="inline-flex items-center gap-1">

--- a/src/pages/trade-crm/MyLeads.tsx
+++ b/src/pages/trade-crm/MyLeads.tsx
@@ -37,6 +37,7 @@ import {
   Users,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getTradeLabel } from '@/lib/jobCategories';
 
 const STATUS_META: Record<string, { label: string; tone: 'neutral' | 'info' | 'success' }> = {
   todo: { label: 'To Do', tone: 'neutral' },
@@ -87,7 +88,6 @@ function toCsv(rows: LeadRow[]): string {
 
 export default function MyLeads() {
   const navigate = useNavigate();
-  const [statusFilter, setStatusFilter] = useState('all');
   const [query, setQuery] = useState('');
 
   const { data: jobs = [], isLoading: jobsLoading, isError } = useQuery({
@@ -121,26 +121,17 @@ export default function MyLeads() {
     });
   }, [jobs, myBids]);
 
-  const counts = useMemo(
-    () => ({
-      all: rows.length,
-      todo: rows.filter(r => r.status === 'todo').length,
-      in_progress: rows.filter(r => r.status === 'in_progress').length,
-      completed: rows.filter(r => r.status === 'completed').length,
-    }),
-    [rows]
-  );
+  const counts = useMemo(() => ({ all: rows.length }), [rows]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return rows.filter(r => {
-      if (statusFilter !== 'all' && r.status !== statusFilter) return false;
       if (!q) return true;
       return (
         (r.customerName ?? '').toLowerCase().includes(q) || r.jobTitle.toLowerCase().includes(q)
       );
     });
-  }, [rows, statusFilter, query]);
+  }, [rows, query]);
 
   const handleExport = () => {
     const blob = new Blob([toCsv(filtered)], { type: 'text/csv;charset=utf-8' });
@@ -175,14 +166,9 @@ export default function MyLeads() {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <SegmentedControl
-          value={statusFilter}
-          onChange={setStatusFilter}
-          items={[
-            { value: 'all', label: 'All', count: counts.all },
-            { value: 'todo', label: 'To Do', count: counts.todo },
-            { value: 'in_progress', label: 'In Progress', count: counts.in_progress },
-            { value: 'completed', label: 'Completed', count: counts.completed },
-          ]}
+          value="all"
+          onChange={() => {}}
+          items={[{ value: 'all', label: 'All', count: counts.all }]}
         />
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
@@ -275,7 +261,7 @@ export default function MyLeads() {
                             </Badge>
                           )}
                           {row.trade && (
-                            <span className="text-xs capitalize text-muted-foreground">{row.trade}</span>
+                            <span className="text-xs text-muted-foreground">{getTradeLabel(row.trade)}</span>
                           )}
                         </span>
                       </div>

--- a/src/pages/trade-crm/TradeCRMProfile.tsx
+++ b/src/pages/trade-crm/TradeCRMProfile.tsx
@@ -11,7 +11,9 @@ import {
   createTradeService,
   updateTradeService,
   deleteTradeService,
+  uploadTraderPhoto,
 } from '@/lib/api';
+import { ME_URL } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -41,7 +43,7 @@ import { profileStrength } from '@/lib/profileStrength';
 import {
   FileText, Trash2, ExternalLink, Plus, Pencil, MapPin,
   User, Building2, ShieldCheck, Wrench, Coins, Clock,
-  Phone, Mail, CheckCircle2, BadgeCheck, Map as MapIcon,
+  Phone, Mail, CheckCircle2, BadgeCheck, Map as MapIcon, Camera,
 } from 'lucide-react';
 import TradeAreaMap, { type LocationChange } from '@/components/Trade-CRM/TradeAreaMap';
 import { cn } from '@/lib/utils';
@@ -160,6 +162,25 @@ const TradeCRMProfile = () => {
       has_license: hasLicense,
     });
 
+  const photoInputRef = useRef<HTMLInputElement>(null);
+  const uploadPhotoMutation = useMutation({
+    mutationFn: uploadTraderPhoto,
+    onSuccess: (res: any) => {
+      queryClient.setQueryData([ME_URL], res);
+      toast({ title: 'Profile photo updated' });
+    },
+    onError: () => toast({ title: 'Photo upload failed', variant: 'destructive' } as any),
+  });
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    uploadPhotoMutation.mutate(fd);
+  };
+
   const { data: documents = [], isLoading: docsLoading } = useQuery({
     queryKey: ['tradeDocuments'],
     queryFn: fetchTradeDocuments,
@@ -254,11 +275,30 @@ const TradeCRMProfile = () => {
       {/* Header card */}
       <SectionCard>
         <div className="flex flex-col items-start gap-5 sm:flex-row sm:items-center">
-          <UserAvatar
-            name={fullName || businessName}
-            size="xl"
-            verified={!!profile?.is_verified || hasVerifiedDoc}
-          />
+          <div className="relative shrink-0">
+            <UserAvatar
+              name={fullName || businessName}
+              src={profile?.profile_photo_url}
+              size="xl"
+              verified={!!profile?.is_verified || hasVerifiedDoc}
+            />
+            <button
+              type="button"
+              onClick={() => photoInputRef.current?.click()}
+              disabled={uploadPhotoMutation.isPending}
+              className="absolute -bottom-1 -right-1 inline-flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-navy-700 text-white shadow-sm hover:bg-navy-800 disabled:opacity-60"
+              aria-label="Change profile photo"
+            >
+              <Camera className="h-3 w-3" />
+            </button>
+            <input
+              ref={photoInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="hidden"
+              onChange={handlePhotoChange}
+            />
+          </div>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <h2 className="truncate text-h2 font-semibold text-foreground">


### PR DESCRIPTION
…der profile photos

* Added a 4-bid cap per job (MAX_BIDS_PER_JOB): the jobs feed now shows X/4 bid counts and a "Bidding closed" state, disabling bidding once a job is full
* Added staged homeowner contact reveal — location unlocks when a bid is placed, while full name, email and phone unlock only after the homeowner accepts, with a blurred locked placeholder in between
* Added a My Bids detail sheet surfacing the bid message, amount, submission time, availability, job status, rating and homeowner contact
* Added trader profile photo upload on the CRM profile: camera control, client-side image-type restriction, upload mutation, and me-cache refresh on success
* Added the uploadTraderPhoto API helper, exported ME_URL, and extended TradePilotUser with profile_photo_url
* Refactored trade-label display into a shared getTradeLabel helper (mirrors backend trade choices) used across the jobs feed, kanban board, dashboard and leads
* Improved the TradeJobs board to render the kanban/drag-and-drop context only when jobs exist, showing a clean empty state otherwise
* Fixed answer-key formatting with a formatAnswerKey helper and prevented card click-through on the "View contact" action
* Removed the non-functional auto top-up switch and "Billing settings" placeholder from Credits, and simplified My Leads to a search-only view by dropping the unimplemented status filter